### PR TITLE
Basic architecture, code up download from drive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 
 # User-specific files
 .Ruserdata
+.Renviron
 
 # RStudio files
 .Rproj.user/
+
+# data symlink
+data

--- a/HRT_global_SWOT.Rproj
+++ b/HRT_global_SWOT.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX

--- a/admin/download_resources.Rmd
+++ b/admin/download_resources.Rmd
@@ -9,7 +9,32 @@ output: html_document
 library(tidyverse)
 library(googledrive)
 
-# authorize drive - requires .renviron document
+# authorize drive - requires .renviron document with valid email
 drive_auth(Sys.getenv("google_email"))
+```
+
+And now get the file list from the google folder.
+
+Get folder id
+```{r}
+folder <- drive_find(pattern = Sys.getenv("folder_name"))
+```
+
+And list files
+```{r}
+files <- drive_ls(folder$id)
+```
+
+And download files to data symlink folder (data symlink is not tracked in GH)
+```{r}
+download_from_drive <- function(filename, fileid, dest_filepath) {
+  drive_download(file = as_id(fileid), path = file.path(dest_filepath, filename))
+}
+
+pwalk(list(files$name, 
+           files$id, 
+           list("data/download/")),
+      download_from_drive
+)
 ```
 

--- a/admin/download_resources.Rmd
+++ b/admin/download_resources.Rmd
@@ -1,0 +1,15 @@
+---
+title: "Download Resources from Drive"
+author: "ROSSyndicate"
+date: "2023-11-15"
+output: html_document
+---
+
+```{r}
+library(tidyverse)
+library(googledrive)
+
+# authorize drive - requires .renviron document
+drive_auth(Sys.getenv("google_email"))
+```
+


### PR DESCRIPTION
Downloading the zips from drive in the browser failed because the folders are so big. Solution: use {googledrive}. :)

Until next week!